### PR TITLE
increase line height to w3 standards

### DIFF
--- a/src/layout/Layout.astro
+++ b/src/layout/Layout.astro
@@ -106,7 +106,7 @@ const rssFeedURL = new URL('rss.xml', Astro.site).href;
   body {
     font-weight: 300;
     min-height: 100vh;
-    line-height: 1;
+    line-height: 1.5;
     list-style-type: none;
     font-size: 16px;
     display: flex;


### PR DESCRIPTION
as a limited vision user, the current line-height set to 1 makes the text hard to read.

i changed it to 1.5 which is the recommended value by w3 standards.

mdn for line-height https://developer.mozilla.org/en-US/docs/Web/CSS/line-height

w3 doc https://www.w3.org/WAI/WCAG21/Understanding/text-spacing.html