### PR TITLE
fix(toc): fix toc disappearing on medium-sized screens

### DIFF
--- a/src/pages/blog/[slug]/index.astro
+++ b/src/pages/blog/[slug]/index.astro
@@ -147,14 +147,17 @@ const readingTime = remarkPluginFrontmatter.readingTime;
     padding: var(--spacing-2x);
   }
 
-  @media screen and (min-width: 425px) {
+  .toc--wrapper {
+    background: #f5f5f5;
+    padding: var(--spacing);
+  }
+
+  @media screen and (min-width: 1024px) {
     .toc--wrapper {
-      background: #f5f5f5;
       position: absolute;
       top: 5px;
       left: -300px;
       width: 270px;
-      padding: var(--spacing);
     }
   }
 


### PR DESCRIPTION
Before, the TOC would appear like this: 

![image](https://github.com/user-attachments/assets/77745d44-de9b-4fdc-b8d2-32cae8905f3e)

Now, it only goes to the side then it reaches 1024px:

![image](https://github.com/user-attachments/assets/420608ec-487a-4fa8-bd41-ee6a221489fd)

---

![image](https://github.com/user-attachments/assets/05e7cac8-64a9-4db7-884f-5cbed229a8b0)
