### PR TITLE
Add hidden posts that render but stay out of all listings

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -33,8 +33,17 @@ const getBlogRoutesRedirect = async () => {
   return Object.fromEntries(blogRoutes);
 }
 
+const getHiddenBlogPaths = async () => {
+  const blogFiles = await fs.readdir(BLOG_DIR);
+  return blogFiles
+    .map(post => graymatter.read(path.join(BLOG_DIR, post)).data)
+    .filter(data => data.hidden)
+    .map(data => `/blog/${data.slug}`);
+}
+
 const disableSitemap = [
   '/blog/drafts',
+  ...await getHiddenBlogPaths(),
 ];
 
 // https://astro.build/config
@@ -45,7 +54,9 @@ export default defineConfig({
       filter: (page) => {
         try {
           const url = new URL(page);
-          const shouldAdd = disableSitemap.every(path => !url.pathname.startsWith(path));
+          const shouldAdd = disableSitemap.every(
+            path => url.pathname !== path && !url.pathname.startsWith(`${path}/`)
+          );
           return shouldAdd;
         } catch (err) {
           return false;

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -9,6 +9,9 @@ const blogCollection = defineCollection({
       pubDate: z.coerce.date(),
       tags: z.array(z.string()).default([]).optional(),
       draft: z.boolean().optional(),
+      // Hidden posts render at their URL (shareable) but never appear in any
+      // listing, RSS feed, tag page, or the sitemap.
+      hidden: z.boolean().optional(),
     })
     .merge(rssSchema)
 });

--- a/src/pages/blog/drafts.astro
+++ b/src/pages/blog/drafts.astro
@@ -5,7 +5,7 @@ import Layout from "../../layout/Layout.astro";
 import Link from '../../components/Link.astro';
 import GoBackButton from '../../components/GoBackButton.astro';
 
-const draftPosts = await getCollection('blog', ({ data }) => data.draft);
+const draftPosts = await getCollection('blog', ({ data }) => data.draft && !data.hidden);
 
 ---
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -5,7 +5,7 @@ import Layout from "../../layout/Layout.astro";
 import Link from '../../components/Link.astro';
 import GoBackButton from '../../components/GoBackButton.astro';
 
-const posts = await getCollection('blog', ({ data }) => !data.draft);
+const posts = await getCollection('blog', ({ data }) => !data.draft && !data.hidden);
 const postsSorted = posts.sort((a, b) =>
   Math.floor(b.data.pubDate / 1000) -
   Math.floor(a.data.pubDate / 1000)

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,7 +6,7 @@ import Link from "../components/Link.astro";
 import { GITHUB_REPO_URL, TWITTER_URL, GITHUB_PROFILE_URL } from '../config';
 import dayjs from 'dayjs';
 
-const posts = await getCollection('blog', ({ data }) => !data.draft);
+const posts = await getCollection('blog', ({ data }) => !data.draft && !data.hidden);
 const postsSorted = posts.sort((a, b) =>
   Math.floor(b.data.pubDate / 1000) -
   Math.floor(a.data.pubDate / 1000)

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -8,10 +8,10 @@ import { SITE } from "../config";
 const parser = new MarkdownIt();
 
 export async function GET() {
-  const posts = await getCollection("blog", ({ data }) => !data.draft);
+  const posts = await getCollection("blog", ({ data }) => !data.draft && !data.hidden);
 
   const items = posts
-    .filter(post => !post.data.draft)
+    .filter(post => !post.data.draft && !post.data.hidden)
     .sort((a, b) => new Date(b.data.pubDate) - new Date(a.data.pubDate))
     .map(({ data, slug, body }) => ({
       link: `/blog/${slug}`,

--- a/src/pages/tag/[tag].astro
+++ b/src/pages/tag/[tag].astro
@@ -13,7 +13,7 @@ interface Props {
 
 export const prerender = true;
 export async function getStaticPaths(): Promise<GetStaticPathsResult> {
-  const posts = await getCollection('blog', (post) => !post.data.draft);
+  const posts = await getCollection('blog', (post) => !post.data.draft && !post.data.hidden);
 
   const existentTags = posts.reduce(
     (tags, post) => new Set([...tags, ...post.data.tags || []]),

--- a/src/pages/tags.astro
+++ b/src/pages/tags.astro
@@ -5,7 +5,7 @@ import Layout from "../layout/Layout.astro";
 import Link from '../components/Link.astro';
 import GoBackButton from '../components/GoBackButton.astro';
 
-const posts = await getCollection('blog', ({ data }) => !data.draft);
+const posts = await getCollection('blog', ({ data }) => !data.draft && !data.hidden);
 
 const tags = posts.reduce<{ [tag: string]: number }>((acc, post) => {
   post.data.tags.forEach((tag: string) => {


### PR DESCRIPTION
Hidden posts (hidden: true in frontmatter) get a page at /blog/<slug> so they can be shared by direct link, but never show up in the home archive, blog index, tag pages, RSS feed, or the sitemap. Different from drafts, which still appear on the /blog/drafts list.